### PR TITLE
Work navigation

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
         <div class="content-wrap">
             <nav>
                 <a href="#about-me">{{ with .Site.Params.about.title }}{{ . }}{{ end }}</a>
-                <a href="#work">{{ with .Site.Params.work.title }}{{ . }}{{ end }}</a>
+                <a href="#work">{{ with .Site.Data.work.title }}{{ . }}{{ end }}</a>
                 <a href="#clients">{{ with .Site.Params.clients.title }}{{ . }}{{ end }}</a>
                 <a href="#contact">{{ with .Site.Params.contact.title }}{{ . }}{{ end }}</a>
             </nav>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 <header id="header">
     <nav>
         <a href="#about-me">{{ with .Site.Params.about.title }}{{ . }}{{ end }}</a>
-        <a href="#work">{{ with .Site.Params.work.title }}{{ . }}{{ end }}</a>
+        <a href="#work">{{ with .Site.Data.work.title }}{{ . }}{{ end }}</a>
         <a href="#clients">{{ with .Site.Params.clients.title }}{{ . }}{{ end }}</a>
         <a href="#contact">{{ with .Site.Params.contact.title }}{{ . }}{{ end }}</a>
     </nav>


### PR DESCRIPTION
Navigation from the header to the work section was missing because the code was accessing a wrong place. The work title is defined in data/work.toml.
