### PR TITLE
Changed header.html to display clients link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
     <nav>
         {{ with .Site.Params.about.title }}<a href="#about-me">{{ . }}</a>{{ end }}
         {{ with .Site.Data.work.title }}<a href="#work">{{ . }}</a>{{ end }}
-        {{ with .Site.Params.clients.title }}<a href="#clients">{{ . }}</a>{{ end }}
+        {{ with .Site.Data.clients.title }}<a href="#clients">{{ . }}</a>{{ end }}
         {{ with .Site.Params.contact.title }}<a href="#contact">{{ . }}</a>{{ end }}
     </nav>
     {{ with .Site.Params.header.title }}<h1><span>{{ . }}</span></h1>{{ end }}


### PR DESCRIPTION
Changed #clients element in the header to activate when data/clients.toml exists, as in ExampleSite. It was not working that way before.
